### PR TITLE
Require CMake 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.27)
 project(
     cppfront
     LANGUAGES CXX


### PR DESCRIPTION
The executable alias cppfront::cppfront doesn't work on 3.26 and earlier.